### PR TITLE
chore: remove useless and problematic import ahead of Scala 3.8.0

### DIFF
--- a/src/test/scala/org/beangle/commons/NumbersTest.scala
+++ b/src/test/scala/org/beangle/commons/NumbersTest.scala
@@ -22,8 +22,6 @@ import org.beangle.commons.lang.Numbers.*
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.runtime.stdLibPatches.Predef.assert
-
 class NumbersTest extends AnyFunSpec, Matchers {
 
   describe("Numbers") {


### PR DESCRIPTION
Importing from `scala.runtime.stdLibPatches.Predef` should never be used and this import will become problematic starting from Scala 3.8.0.
In this PR, we fix this by removing the import and rely on the automatic insertion of `import scala.Predef.*`.

Related to https://github.com/scala/scala3/issues/23804